### PR TITLE
Refactor all action names to match a predefined rules

### DIFF
--- a/app/actions/announcement.js
+++ b/app/actions/announcement.js
@@ -2,34 +2,37 @@
 
 import _ from 'lodash';
 import api from '../services/api';
+import {createRequestActionTypes} from '.';
 
-const ANNOUNCEMENT_SET = 'ANNOUNCEMENT_SET';
-const ANNOUNCEMENT_LIST_LOADING = 'ANNOUNCEMENT_LIST_LOADING';
-const ANNOUNCEMENT_LIST_LOADED = 'ANNOUNCEMENT_LIST_LOADED';
-const ANNOUNCEMENT_LIST_FAILED = 'ANNOUNCEMENT_LIST_FAILED';
+const SET_ANNOUNCEMENT_LIST = 'SET_ANNOUNCEMENT_LIST';
+const {
+  GET_ANNOUNCEMENT_LIST_REQUEST,
+  GET_ANNOUNCEMENT_LIST_SUCCESS,
+  GET_ANNOUNCEMENT_LIST_FAILURE
+} = createRequestActionTypes('GET_ANNOUNCEMENT_LIST');
 
 const fetchAnnouncements = () => {
   return (dispatch) => {
-    dispatch({ type: ANNOUNCEMENT_LIST_LOADING });
+    dispatch({ type: GET_ANNOUNCEMENT_LIST_REQUEST });
 
     api.fetchModels('announcements')
       .then(announcements => {
         announcements = _.isArray(announcements) ? announcements : [announcements];
 
         dispatch({
-          type: ANNOUNCEMENT_SET,
+          type: SET_ANNOUNCEMENT_LIST,
           payload: announcements
         });
-        dispatch({ type: ANNOUNCEMENT_LIST_LOADED });
+        dispatch({ type: GET_ANNOUNCEMENT_LIST_SUCCESS });
       })
-      .catch(error => dispatch({ type: ANNOUNCEMENT_LIST_FAILED }));
+      .catch(error => dispatch({ type: GET_ANNOUNCEMENT_LIST_FAILURE }));
   }
 };
 
 export {
-  ANNOUNCEMENT_SET,
-  ANNOUNCEMENT_LIST_LOADING,
-  ANNOUNCEMENT_LIST_LOADED,
-  ANNOUNCEMENT_LIST_FAILED,
+  SET_ANNOUNCEMENT_LIST,
+  GET_ANNOUNCEMENT_LIST_REQUEST,
+  GET_ANNOUNCEMENT_LIST_SUCCESS,
+  GET_ANNOUNCEMENT_LIST_FAILURE,
   fetchAnnouncements
 };

--- a/app/actions/competition.js
+++ b/app/actions/competition.js
@@ -4,13 +4,19 @@ import api from '../services/api';
 import ActionTypes from '../constants/ActionTypes';
 import * as NotificationMessages from '../utils/notificationMessage';
 import { refreshFeed } from './feed';
+import {createRequestActionTypes} from '.';
 
-const POSTING_ACTION = 'POSTING_ACTION';
-const ACTION_POST_SUCCESS = 'ACTION_POST_SUCCESS';
-const ACTION_POST_FAILURE = 'ACTION_POST_FAILURE';
-const REQUEST_ACTION_TYPES = 'REQUEST_ACTION_TYPES';
-const RECEIVE_ACTION_TYPES = 'RECEIVE_ACTION_TYPES';
-const ERROR_REQUESTING_ACTION_TYPES = 'ERROR_REQUESTING_ACTION_TYPES';
+const {
+  POST_ACTION_REQUEST,
+  POST_ACTION_SUCCESS,
+  POST_ACTION_FAILURE
+} = createRequestActionTypes('POST_ACTION');
+const {
+  GET_ACTION_TYPES_REQUEST,
+  GET_ACTION_TYPES_SUCCESS,
+  GET_ACTION_TYPES_FAILURE
+} = createRequestActionTypes('GET_ACTION_TYPES');
+
 const OPEN_TEXTACTION_VIEW = 'OPEN_TEXTACTION_VIEW';
 const CLOSE_TEXTACTION_VIEW = 'CLOSE_TEXTACTION_VIEW';
 const SHOW_NOTIFICATION = 'SHOW_NOTIFICATION';
@@ -27,11 +33,11 @@ const closeTextActionView = () => {
 
 const _postAction = (payload) => {
   return (dispatch, getStore) => {
-    dispatch({ type: POSTING_ACTION });
+    dispatch({ type: POST_ACTION_REQUEST });
 
     return api.postAction(payload, getStore().location.get('currentLocation'))
       .then(response => {
-        dispatch({ type: ACTION_POST_SUCCESS, payload: { type: payload.type } });
+        dispatch({ type: POST_ACTION_SUCCESS, payload: { type: payload.type } });
         dispatch({ type: SHOW_NOTIFICATION, payload: NotificationMessages.getMessage(payload) });
         dispatch(refreshFeed());
 
@@ -53,7 +59,7 @@ const _postAction = (payload) => {
             payload: NotificationMessages.getErrorMessage(payload)
           });
         }
-        dispatch({ type: ACTION_POST_FAILURE, error: e });
+        dispatch({ type: POST_ACTION_FAILURE, error: e });
 
         setTimeout(() => {
           dispatch({ type: HIDE_NOTIFICATION });
@@ -84,10 +90,10 @@ const postImage = image => {
 
 const fetchActionTypes = () => {
   return dispatch => {
-    dispatch({ type: REQUEST_ACTION_TYPES });
+    dispatch({ type: GET_ACTION_TYPES_REQUEST });
     api.fetchModels('actionTypes')
-      .then(actionTypes => dispatch({ type: RECEIVE_ACTION_TYPES, payload: actionTypes }))
-      .catch(e => dispatch({ type: ERROR_REQUESTING_ACTION_TYPES, error: e }));
+      .then(actionTypes => dispatch({ type: GET_ACTION_TYPES_SUCCESS, payload: actionTypes }))
+      .catch(e => dispatch({ type: GET_ACTION_TYPES_FAILURE, error: e }));
   };
 };
 
@@ -96,12 +102,12 @@ const updateCooldowns = () => {
 };
 
 export {
-  POSTING_ACTION,
-  ACTION_POST_SUCCESS,
-  ACTION_POST_FAILURE,
-  REQUEST_ACTION_TYPES,
-  RECEIVE_ACTION_TYPES,
-  ERROR_REQUESTING_ACTION_TYPES,
+  POST_ACTION_REQUEST,
+  POST_ACTION_SUCCESS,
+  POST_ACTION_FAILURE,
+  GET_ACTION_TYPES_REQUEST,
+  GET_ACTION_TYPES_SUCCESS,
+  GET_ACTION_TYPES_FAILURE,
   OPEN_TEXTACTION_VIEW,
   CLOSE_TEXTACTION_VIEW,
   SHOW_NOTIFICATION,

--- a/app/actions/event.js
+++ b/app/actions/event.js
@@ -1,45 +1,47 @@
-'use strict';
-
 import api from '../services/api';
+import {createRequestActionTypes} from '.';
 
-const EVENT_SET = 'EVENT_SET';
-const EVENT_LIST_LOADING = 'EVENT_LIST_LOADING';
-const EVENT_LIST_LOADED = 'EVENT_LIST_LOADED';
-const EVENT_LIST_FAILED = 'EVENT_LIST_FAILED';
-const EVENT_SHOWFILTER_UPDATE = 'EVENT_SHOWFILTER_UPDATE';
-const EVENT_MAP_LOCATE_TOGGLE = 'EVENT_MAP_LOCATE_TOGGLE';
+const SET_EVENT_LIST = 'SET_EVENT_LIST';
+const {
+  GET_EVENT_LIST_REQUEST,
+  GET_EVENT_LIST_SUCCESS,
+  GET_EVENT_LIST_FAILURE
+} = createRequestActionTypes('GET_EVENT_LIST');
+
+const UPDATE_EVENT_SHOWFILTER = 'UPDATE_EVENT_SHOWFILTER';
+const TOGGLE_EVENT_MAP_LOCATE = 'TOGGLE_EVENT_MAP_LOCATE';
 
 const fetchEvents = () => {
   return (dispatch) => {
-    dispatch({ type: EVENT_LIST_LOADING });
+    dispatch({ type: GET_EVENT_LIST_REQUEST });
 
     api.fetchModels('events')
       .then(events => {
         dispatch({
-          type: EVENT_SET,
+          type: SET_EVENT_LIST,
           payload: events
         });
-        dispatch({ type: EVENT_LIST_LOADED });
+        dispatch({ type: GET_EVENT_LIST_SUCCESS });
       })
-      .catch(error => dispatch({ type: EVENT_LIST_FAILED }));
+      .catch(error => dispatch({ type: GET_EVENT_LIST_FAILURE }));
   }
 };
 
 const updateShowFilter = filterName => {
-  return { type: EVENT_SHOWFILTER_UPDATE, payload: filterName };
+  return { type: UPDATE_EVENT_SHOWFILTER, payload: filterName };
 };
 
 const toggleLocateMe = () => {
-  return { type: EVENT_MAP_LOCATE_TOGGLE };
+  return { type: TOGGLE_EVENT_MAP_LOCATE };
 }
 
 export {
-  EVENT_SET,
-  EVENT_LIST_LOADING,
-  EVENT_LIST_LOADED,
-  EVENT_LIST_FAILED,
-  EVENT_SHOWFILTER_UPDATE,
-  EVENT_MAP_LOCATE_TOGGLE,
+  SET_EVENT_LIST,
+  GET_EVENT_LIST_REQUEST,
+  GET_EVENT_LIST_SUCCESS,
+  GET_EVENT_LIST_FAILURE,
+  UPDATE_EVENT_SHOWFILTER,
+  TOGGLE_EVENT_MAP_LOCATE,
   fetchEvents,
   updateShowFilter,
   toggleLocateMe

--- a/app/actions/feed.js
+++ b/app/actions/feed.js
@@ -1,64 +1,70 @@
-'use strict';
-
 import api from '../services/api';
+import {createRequestActionTypes} from '.';
 
-const FEED_SET = 'FEED_SET';
-const FEED_APPEND = 'FEED_APPEND';
-const FEED_LIST_LOADING = 'FEED_LIST_LOADING';
-const FEED_LIST_LOADED = 'FEED_LIST_LOADED';
-const FEED_LIST_FAILED = 'FEED_LIST_FAILED';
-const FEED_LIST_REFRESHING = 'FEED_LIST_REFRESHING';
-const FEED_LIST_REFRESHED = 'FEED_LIST_REFRESHED';
-const FEED_ITEM_DELETE = 'FEED_ITEM_DELETE';
+const SET_FEED = 'SET_FEED';
+const APPEND_FEED = 'APPEND_FEED';
+
+const {
+  GET_FEED_REQUEST,
+  GET_FEED_SUCCESS,
+  GET_FEED_FAILURE
+} = createRequestActionTypes('GET_FEED');
+const {
+  REFRESH_FEED_REQUEST,
+  REFRESH_FEED_SUCCESS,
+  // Failure of refresh is also modeled as "success"
+  // REFRESH_FEED_FAILURE
+} = createRequestActionTypes('REFRESH_FEED');
+const DELETE_FEED_ITEM = 'DELETE_FEED_ITEM';
 
 const fetchFeed = () => {
   return (dispatch) => {
-    dispatch({ type: FEED_LIST_LOADING });
+    dispatch({ type: GET_FEED_REQUEST });
 
     api.fetchModels('feed')
       .then(items => {
         dispatch({
-          type: FEED_SET,
+          type: SET_FEED,
           feed: items
         });
 
-        dispatch({ type: FEED_LIST_LOADED });
+        dispatch({ type: GET_FEED_SUCCESS });
       })
-      .catch(error => dispatch({ type: FEED_LIST_FAILED }));
+      .catch(error => dispatch({ type: GET_FEED_FAILURE }));
   };
 };
 
 const refreshFeed = () => {
   return (dispatch) => {
 
-    dispatch({ type: FEED_LIST_REFRESHING });
+    dispatch({ type: REFRESH_FEED_REQUEST });
     api.fetchModels('feed')
       .then(items => {
         dispatch({
-          type: FEED_SET,
+          type: SET_FEED,
           feed: items
         });
-        dispatch({ type: FEED_LIST_REFRESHED });
-        dispatch({ type: FEED_LIST_LOADED });
+        dispatch({ type: REFRESH_FEED_SUCCESS });
+        dispatch({ type: GET_FEED_SUCCESS });
       })
-      .catch(error => dispatch({ type: FEED_LIST_REFRESHED }));
+      .catch(error => dispatch({ type: REFRESH_FEED_SUCCESS }));
   };
 };
 
 const loadMoreItems = (lastID) => {
   return (dispatch) => {
 
-    dispatch({ type: FEED_LIST_REFRESHING });
+    dispatch({ type: REFRESH_FEED_REQUEST });
     api.fetchMoreFeed(lastID)
       .then(items => {
         dispatch({
-          type: FEED_APPEND,
+          type: APPEND_FEED,
           feed: items
         });
-        dispatch({ type: FEED_LIST_REFRESHED });
-        dispatch({ type: FEED_LIST_LOADED });
+        dispatch({ type: REFRESH_FEED_SUCCESS });
+        dispatch({ type: GET_FEED_SUCCESS });
       })
-      .catch(error => dispatch({ type: FEED_LIST_REFRESHED }));
+      .catch(error => dispatch({ type: REFRESH_FEED_SUCCESS }));
   };
 };
 
@@ -66,7 +72,7 @@ const removeFeedItem = (item) => {
   return dispatch => {
     api.deleteFeedItem(item)
       .then(() => dispatch({
-        type: FEED_ITEM_DELETE,
+        type: DELETE_FEED_ITEM,
         item
       }))
       .catch(error => console.log('Error when trying to delete feed item', error));
@@ -74,14 +80,14 @@ const removeFeedItem = (item) => {
 };
 
 export {
-  FEED_SET,
-  FEED_APPEND,
-  FEED_LIST_LOADING,
-  FEED_LIST_LOADED,
-  FEED_LIST_FAILED,
-  FEED_LIST_REFRESHING,
-  FEED_LIST_REFRESHED,
-  FEED_ITEM_DELETE,
+  SET_FEED,
+  APPEND_FEED,
+  GET_FEED_REQUEST,
+  GET_FEED_SUCCESS,
+  GET_FEED_FAILURE,
+  REFRESH_FEED_REQUEST,
+  REFRESH_FEED_SUCCESS,
+  DELETE_FEED_ITEM,
 
   fetchFeed,
   refreshFeed,

--- a/app/actions/marker.js
+++ b/app/actions/marker.js
@@ -1,32 +1,33 @@
-'use strict';
-
 import api from '../services/api';
+import {createRequestActionTypes} from '.';
 
-const MARKER_SET = 'MARKER_SET';
-const MARKER_LIST_LOADING = 'MARKER_LIST_LOADING';
-const MARKER_LIST_LOADED = 'MARKER_LIST_LOADED';
-const MARKER_LIST_FAILED = 'MARKER_LIST_FAILED';
+const SET_MARKER_LIST = 'SET_MARKER_LIST';
+const {
+  GET_MARKER_LIST_REQUEST,
+  GET_MARKER_LIST_SUCCESS,
+  GET_MARKER_LIST_FAILURE
+} = createRequestActionTypes('GET_MARKER_LIST');
 
 const fetchMarkers = () => {
   return (dispatch) => {
-    dispatch({ type: MARKER_LIST_LOADING });
+    dispatch({ type: GET_MARKER_LIST_REQUEST });
 
     api.fetchModels('markers')
       .then(events => {
         dispatch({
-          type: MARKER_SET,
+          type: SET_MARKER_LIST,
           payload: events
         });
-        dispatch({ type: MARKER_LIST_LOADED });
+        dispatch({ type: GET_MARKER_LIST_SUCCESS });
       })
-      .catch(error => dispatch({ type: MARKER_LIST_FAILED }));
+      .catch(error => dispatch({ type: GET_MARKER_LIST_FAILURE }));
   }
 };
 
 export {
-  MARKER_SET,
-  MARKER_LIST_LOADING,
-  MARKER_LIST_LOADED,
-  MARKER_LIST_FAILED,
+  SET_MARKER_LIST,
+  GET_MARKER_LIST_REQUEST,
+  GET_MARKER_LIST_SUCCESS,
+  GET_MARKER_LIST_FAILURE,
   fetchMarkers
 };

--- a/app/actions/profile.js
+++ b/app/actions/profile.js
@@ -2,15 +2,15 @@
 
 import Links from '../constants/Links';
 
-const LINK_SET = 'LINK_SET';
+const SET_LINK = 'SET_LINK';
 
 const fetchLinks = () => {
   return (dispatch) => {
-    dispatch({ type: LINK_SET, links: Links.terms });
+    dispatch({ type: SET_LINK, links: Links.terms });
   }
 };
 
 export {
-  LINK_SET,
+  SET_LINK,
   fetchLinks
 };

--- a/app/actions/registration.js
+++ b/app/actions/registration.js
@@ -2,16 +2,22 @@ import DeviceInfo from 'react-native-device-info';
 import api from '../services/api';
 import namegen from '../services/namegen';
 import _ from 'lodash';
+import {createRequestActionTypes} from '.';
 
-const CREATING_USER = 'CREATING_USER';
-const USER_CREATE_SUCCESS = 'USER_CREATE_SUCCESS';
-const USER_CREATE_FAILURE = 'USER_CREATE_FAILURE';
+const {
+  CREATE_USER_REQUEST,
+  CREATE_USER_SUCCESS,
+  CREATE_USER_FAILURE
+} = createRequestActionTypes('CREATE_USER');
+const {
+  GET_USER_REQUEST,
+  GET_USER_SUCCESS,
+  GET_USER_FAILURE
+} = createRequestActionTypes('GET_USER');
+
 const OPEN_REGISTRATION_VIEW = 'OPEN_REGISTRATION_VIEW';
 const CLOSE_REGISTRATION_VIEW = 'CLOSE_REGISTRATION_VIEW';
 const UPDATE_NAME = 'UPDATE_NAME';
-const REQUEST_NAME = 'REQUEST_NAME';
-const RECEIVE_USER = 'RECEIVE_NAME';
-const ERROR_REQUESTING_USER = 'ERROR_REQUESTING_USER';
 const SELECT_TEAM = 'SELECT_TEAM';
 const CLOSE_TEAM_SELECTOR = 'CLOSE_TEAM_SELECTOR';
 
@@ -25,16 +31,16 @@ const closeRegistrationView = () => {
 
 const putUser = () => {
   return (dispatch, getStore) => {
-    dispatch({ type: CREATING_USER });
+    dispatch({ type: CREATE_USER_REQUEST });
     const uuid = DeviceInfo.getUniqueID();
     const name = getStore().registration.get('name');
     const team = getStore().registration.get('selectedTeam');
     return api.putUser({ uuid, name, team })
       .then(response => {
-        dispatch({ type: USER_CREATE_SUCCESS });
+        dispatch({ type: CREATE_USER_SUCCESS });
         dispatch({ type: CLOSE_REGISTRATION_VIEW });
       })
-      .catch(error => dispatch({ type: USER_CREATE_FAILURE, error: error }));
+      .catch(error => dispatch({ type: CREATE_USER_FAILURE, error: error }));
   };
 };
 const selectTeam = team => {
@@ -67,28 +73,28 @@ const generateName = () => {
 
 const getUser = () => {
   return dispatch => {
-    dispatch({ type: REQUEST_NAME });
+    dispatch({ type: GET_USER_REQUEST });
     const uuid = DeviceInfo.getUniqueID();
     return api.getUser(uuid)
       .then(user => {
-        dispatch({ type: RECEIVE_USER, payload: user });
+        dispatch({ type: GET_USER_SUCCESS, payload: user });
       })
       .catch(error => {
-        dispatch({ type: ERROR_REQUESTING_USER, error: error });
+        dispatch({ type: GET_USER_FAILURE, error: error });
       });
   };
 };
 
 export {
-  CREATING_USER,
-  USER_CREATE_SUCCESS,
-  USER_CREATE_FAILURE,
+  CREATE_USER_REQUEST,
+  CREATE_USER_SUCCESS,
+  CREATE_USER_FAILURE,
   OPEN_REGISTRATION_VIEW,
   CLOSE_REGISTRATION_VIEW,
   UPDATE_NAME,
-  REQUEST_NAME,
-  RECEIVE_USER,
-  ERROR_REQUESTING_USER,
+  GET_USER_REQUEST,
+  GET_USER_SUCCESS,
+  GET_USER_FAILURE,
   SELECT_TEAM,
   putUser,
   openRegistrationView,

--- a/app/actions/team.js
+++ b/app/actions/team.js
@@ -1,18 +1,21 @@
 'use strict';
 
 import api from '../services/api';
+import {createRequestActionTypes} from '.'
 
-const REQUEST_TEAMS = 'FETCH_TEAMS';
-const RECEIVE_TEAMS = 'RECEIVE_TEAMS';
-const ERROR_REQUESTING_TEAMS = 'ERROR_REQUESTING_TEAMS';
+const {
+  GET_TEAMS_REQUEST,
+  GET_TEAMS_SUCCESS,
+  GET_TEAMS_FAILURE
+} = createRequestActionTypes('GET_TEAMS');
 const SHOW_TEAM_SELECTOR = 'SHOW_TEAM_SELECTOR';
 
 const fetchTeams = () => {
   return dispatch => {
-    dispatch({ type: REQUEST_TEAMS });
+    dispatch({ type: GET_TEAMS_REQUEST });
     api.fetchModels('teams')
-      .then(teams => dispatch({ type: RECEIVE_TEAMS, payload: teams }))
-      .catch(e => dispatch({ type: ERROR_REQUESTING_TEAMS, error: e }));
+      .then(teams => dispatch({ type: GET_TEAMS_SUCCESS, payload: teams }))
+      .catch(e => dispatch({ type: GET_TEAMS_FAILURE, error: e }));
   };
 };
 
@@ -21,9 +24,9 @@ const showChooseTeam = () => {
 };
 
 export {
-  REQUEST_TEAMS,
-  RECEIVE_TEAMS,
-  ERROR_REQUESTING_TEAMS,
+  GET_TEAMS_REQUEST,
+  GET_TEAMS_SUCCESS,
+  GET_TEAMS_FAILURE,
 
   SHOW_TEAM_SELECTOR,
 

--- a/app/reducers/announcement.js
+++ b/app/reducers/announcement.js
@@ -2,10 +2,10 @@
 import Immutable from 'immutable';
 
 import {
-  ANNOUNCEMENT_SET,
-  ANNOUNCEMENT_LIST_LOADING,
-  ANNOUNCEMENT_LIST_LOADED,
-  ANNOUNCEMENT_LIST_FAILED
+  SET_ANNOUNCEMENT_LIST,
+  GET_ANNOUNCEMENT_LIST_REQUEST,
+  GET_ANNOUNCEMENT_LIST_SUCCESS,
+  GET_ANNOUNCEMENT_LIST_FAILURE
 } from '../actions/announcement';
 
 const initialState = Immutable.fromJS({
@@ -15,13 +15,13 @@ const initialState = Immutable.fromJS({
 
 export default function announcement(state = initialState, action) {
   switch (action.type) {
-    case ANNOUNCEMENT_SET:
+    case SET_ANNOUNCEMENT_LIST:
       return state.set('list', Immutable.fromJS(action.payload));
-    case ANNOUNCEMENT_LIST_LOADING:
+    case GET_ANNOUNCEMENT_LIST_REQUEST:
       return state.set('listState', 'loading');
-    case ANNOUNCEMENT_LIST_LOADED:
+    case GET_ANNOUNCEMENT_LIST_SUCCESS:
       return state.set('listState', 'ready');
-    case ANNOUNCEMENT_LIST_FAILED:
+    case GET_ANNOUNCEMENT_LIST_FAILURE:
       return state.set('listState', 'failed');
     default:
       return state;

--- a/app/reducers/competition.js
+++ b/app/reducers/competition.js
@@ -2,12 +2,12 @@
 
 import Immutable from 'immutable';
 import {
-  POSTING_ACTION,
-  ACTION_POST_SUCCESS,
-  ACTION_POST_FAILURE,
-  REQUEST_ACTION_TYPES,
-  RECEIVE_ACTION_TYPES,
-  ERROR_REQUESTING_ACTION_TYPES,
+  POST_ACTION_REQUEST,
+  POST_ACTION_SUCCESS,
+  POST_ACTION_FAILURE,
+  GET_ACTION_TYPES_REQUEST,
+  GET_ACTION_TYPES_SUCCESS,
+  GET_ACTION_TYPES_FAILURE,
   OPEN_TEXTACTION_VIEW,
   CLOSE_TEXTACTION_VIEW,
   SHOW_NOTIFICATION,
@@ -55,12 +55,12 @@ export default function competition(state = initialState, action) {
       return state.set('isTextActionViewOpen', true);
     case CLOSE_TEXTACTION_VIEW:
       return state.set('isTextActionViewOpen', false);
-    case POSTING_ACTION:
+    case POST_ACTION_REQUEST:
       return state.merge({
         isSending: true,
         isError: false
       });
-    case ACTION_POST_SUCCESS:
+    case POST_ACTION_SUCCESS:
       const actionType = state
         .get('actionTypes')
         .find(at => at.get('code') === action.payload.type);
@@ -69,23 +69,23 @@ export default function competition(state = initialState, action) {
       return state
         .merge({ isSending: false, isError: false })
         .update('cooldownTimes', times => times.set(action.payload.type, availableNextTime));
-    case ACTION_POST_FAILURE:
+    case POST_ACTION_FAILURE:
       return state.merge({
         isSending: false,
         isError: true
       });
-    case REQUEST_ACTION_TYPES:
+    case GET_ACTION_TYPES_REQUEST:
       return state.merge({
         isLoadingActionTypes: true,
         isErrorLoadingActionTypes: false
       });
-    case RECEIVE_ACTION_TYPES:
+    case GET_ACTION_TYPES_SUCCESS:
       return state.merge({
         isLoadingActionTypes: false,
         isErrorLoadingActionTypes: false,
         actionTypes: action.payload
       });
-    case ERROR_REQUESTING_ACTION_TYPES:
+    case GET_ACTION_TYPES_FAILURE:
       return state.merge({
         isLoadingActionTypes: false,
         isErrorLoadingActionTypes: true

--- a/app/reducers/event.js
+++ b/app/reducers/event.js
@@ -2,12 +2,12 @@
 import Immutable from 'immutable';
 
 import {
-  EVENT_SET,
-  EVENT_LIST_LOADING,
-  EVENT_LIST_LOADED,
-  EVENT_LIST_FAILED,
-  EVENT_SHOWFILTER_UPDATE,
-  EVENT_MAP_LOCATE_TOGGLE
+  SET_EVENT_LIST,
+  GET_EVENT_LIST_REQUEST,
+  GET_EVENT_LIST_SUCCESS,
+  GET_EVENT_LIST_FAILURE,
+  UPDATE_EVENT_SHOWFILTER,
+  TOGGLE_EVENT_MAP_LOCATE
 } from '../actions/event';
 
 const initialState = Immutable.fromJS({
@@ -19,17 +19,17 @@ const initialState = Immutable.fromJS({
 
 export default function event(state = initialState, action) {
   switch (action.type) {
-    case EVENT_SET:
+    case SET_EVENT_LIST:
       return state.set('list', Immutable.fromJS(action.payload));
-    case EVENT_LIST_LOADING:
+    case GET_EVENT_LIST_REQUEST:
       return state.set('listState', 'loading');
-    case EVENT_LIST_LOADED:
+    case GET_EVENT_LIST_SUCCESS:
       return state.set('listState', 'ready');
-    case EVENT_LIST_FAILED:
+    case GET_EVENT_LIST_FAILURE:
       return state.set('listState', 'failed');
-    case EVENT_SHOWFILTER_UPDATE:
+    case UPDATE_EVENT_SHOWFILTER:
       return state.set('showFilter', Immutable.fromJS(action.payload));
-    case EVENT_MAP_LOCATE_TOGGLE:
+    case TOGGLE_EVENT_MAP_LOCATE:
       return state.set('locateMe', !state.get('locateMe'));
     default:
       return state;

--- a/app/reducers/feed.js
+++ b/app/reducers/feed.js
@@ -2,14 +2,14 @@
 import Immutable from 'immutable';
 
 import {
-  FEED_SET,
-  FEED_APPEND,
-  FEED_LIST_LOADING,
-  FEED_LIST_LOADED,
-  FEED_LIST_FAILED,
-  FEED_LIST_REFRESHING,
-  FEED_LIST_REFRESHED,
-  FEED_ITEM_DELETE
+  SET_FEED,
+  APPEND_FEED,
+  GET_FEED_REQUEST,
+  GET_FEED_SUCCESS,
+  GET_FEED_FAILURE,
+  REFRESH_FEED_REQUEST,
+  REFRESH_FEED_SUCCESS,
+  DELETE_FEED_ITEM
 } from '../actions/feed';
 import LoadingStates from '../constants/LoadingStates';
 
@@ -21,23 +21,23 @@ const initialState = Immutable.fromJS({
 
 export default function feed(state = initialState, action) {
   switch (action.type) {
-    case FEED_SET:
+    case SET_FEED:
       return state.set('list', Immutable.fromJS(action.feed));
-    case FEED_APPEND:
+    case APPEND_FEED:
       return (action.feed && action.feed.length) ?
         state.set('list', state.get('list').concat(action.feed)) :
         state;
-    case FEED_LIST_LOADING:
+    case GET_FEED_REQUEST:
       return state.set('listState', LoadingStates.LOADING);
-    case FEED_LIST_LOADED:
+    case GET_FEED_SUCCESS:
       return state.set('listState', LoadingStates.READY);
-    case FEED_LIST_FAILED:
+    case GET_FEED_FAILURE:
       return state.set('listState', LoadingStates.FAILED);
-    case FEED_LIST_REFRESHING:
+    case REFRESH_FEED_REQUEST:
       return state.set('isRefreshing', true);
-    case FEED_LIST_REFRESHED:
+    case REFRESH_FEED_SUCCESS:
       return state.set('isRefreshing', false);
-    case FEED_ITEM_DELETE:
+    case DELETE_FEED_ITEM:
       const originalList = state.get('list');
       const itemIndex = originalList.findIndex((item) => item.get('id') === action.item.id);
 

--- a/app/reducers/marker.js
+++ b/app/reducers/marker.js
@@ -2,10 +2,10 @@
 import Immutable from 'immutable';
 
 import {
-  MARKER_SET,
-  MARKER_LIST_LOADING,
-  MARKER_LIST_LOADED,
-  MARKER_LIST_FAILED
+  SET_MARKER_LIST,
+  GET_MARKER_LIST_REQUEST,
+  GET_MARKER_LIST_SUCCESS,
+  GET_MARKER_LIST_FAILURE
 } from '../actions/marker';
 
 const initialState = Immutable.fromJS({
@@ -15,13 +15,13 @@ const initialState = Immutable.fromJS({
 
 export default function event(state = initialState, action) {
   switch (action.type) {
-    case MARKER_SET:
+    case SET_MARKER_LIST:
       return state.set('list', Immutable.fromJS(action.payload));
-    case MARKER_LIST_LOADING:
+    case GET_MARKER_LIST_REQUEST:
       return state.set('listState', 'loading');
-    case MARKER_LIST_LOADED:
+    case GET_MARKER_LIST_SUCCESS:
       return state.set('listState', 'ready');
-    case MARKER_LIST_FAILED:
+    case GET_MARKER_LIST_FAILURE:
       return state.set('listState', 'failed');
     default:
       return state;

--- a/app/reducers/profile.js
+++ b/app/reducers/profile.js
@@ -2,7 +2,7 @@
 import Immutable from 'immutable';
 
 import {
-  LINK_SET,
+  SET_LINK,
 } from '../actions/profile';
 
 const initialState = Immutable.fromJS({
@@ -11,7 +11,7 @@ const initialState = Immutable.fromJS({
 
 export default function profile(state = initialState, action) {
   switch (action.type) {
-    case LINK_SET:
+    case SET_LINK:
       return state.set('links', Immutable.fromJS(action.links));
     default:
       return state;

--- a/app/reducers/registration.js
+++ b/app/reducers/registration.js
@@ -2,15 +2,15 @@
 
 import Immutable from 'immutable';
 import {
-  CREATING_USER,
-  USER_CREATE_SUCCESS,
-  USER_CREATE_FAILURE,
+  CREATE_USER_REQUEST,
+  CREATE_USER_SUCCESS,
+  CREATE_USER_FAILURE,
   OPEN_REGISTRATION_VIEW,
   CLOSE_REGISTRATION_VIEW,
   UPDATE_NAME,
-  REQUEST_NAME,
-  RECEIVE_USER,
-  ERROR_REQUESTING_USER,
+  GET_USER_REQUEST,
+  GET_USER_SUCCESS,
+  GET_USER_FAILURE,
   SELECT_TEAM
 } from '../actions/registration';
 
@@ -32,25 +32,25 @@ export default function registration(state = initialState, action) {
       return state.set('name', action.payload);
     case SELECT_TEAM:
       return state.set('selectedTeam', action.payload);
-    case CREATING_USER:
+    case CREATE_USER_REQUEST:
       return state.merge({
         'isLoading': true,
         'isError': false
       });
-    case REQUEST_NAME:
+    case GET_USER_REQUEST:
       return state.set('isLoading', true);
-    case USER_CREATE_SUCCESS:
+    case CREATE_USER_SUCCESS:
       return state.merge({
         'isLoading': false,
         'isError': false
       });
-    case USER_CREATE_FAILURE:
-    case ERROR_REQUESTING_USER:
+    case CREATE_USER_FAILURE:
+    case GET_USER_FAILURE:
       return state.merge({
         'isLoading': false,
         'isError': true
       });
-    case RECEIVE_USER:
+    case GET_USER_SUCCESS:
       return state.merge({
         'name': action.payload.name,
         'selectedTeam': action.payload.team,

--- a/app/reducers/team.js
+++ b/app/reducers/team.js
@@ -2,9 +2,9 @@
 import Immutable from 'immutable';
 
 import {
-  REQUEST_TEAMS,
-  RECEIVE_TEAMS,
-  ERROR_REQUESTING_TEAMS,
+  GET_TEAMS_REQUEST,
+  GET_TEAMS_SUCCESS,
+  GET_TEAMS_FAILURE,
   SHOW_TEAM_SELECTOR,
   CLOSE_TEAM_SELECTOR
 } from '../actions/team';
@@ -19,18 +19,18 @@ const initialState = Immutable.fromJS({
 
 export default function team(state = initialState, action) {
   switch (action.type) {
-    case REQUEST_TEAMS:
+    case GET_TEAMS_REQUEST:
       return state.merge({
         isLoading: true,
         isError: false
       });
-    case RECEIVE_TEAMS:
+    case GET_TEAMS_SUCCESS:
       return state.merge({
         isLoading: false,
         isError: false,
         teams: action.payload
       });
-    case ERROR_REQUESTING_TEAMS:
+    case GET_TEAMS_FAILURE:
       return state.merge({
         isLoading: false,
         isError: true


### PR DESCRIPTION
All asynchronous request actions are now following these conventions:

For example, get user. The base name of the async action is `GET_USER`
- `GET_USER_REQUEST` -> we started fetching user
- `GET_USER_SUCCESS` -> requesting succeeded, payload contains user
- `GET_USER_FAILURE` -> requesting failed, payload contains error
