### PR TITLE
Fix react-native-google-analytics version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "moment": "^2.12.0",
     "react-native": "^0.21.0",
     "react-native-device-info": "^0.8.4",
-    "react-native-google-analytics": "^1.0.1",
+    "react-native-google-analytics": "~1.0.1",
     "react-native-hockeyapp": "^0.3.0",
     "react-native-image-picker": "^0.18.3",
     "react-native-location": "^0.14.3",


### PR DESCRIPTION
Version 1.1.0 breaks the build, because the constructor method of Analytics.js changed
